### PR TITLE
Add reserved option range for mypy-protobuf

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -300,3 +300,7 @@ with info about your project (name and website) so we can add an entry for you.
 1. Protoc-gen-go-svc
    * Website: https://github.com/dane/protoc-gen-go-svc
    * Extension: 1140
+
+1. mypy-protobuf
+   * Website: https://github.com/nipunn1313/mypy-protobuf
+   * Extension: 1141-1149


### PR DESCRIPTION
Mypy-protobuf is here
https://github.com/nipunn1313/mypy-protobuf

It currently uses extensions as explained here.
https://github.com/nipunn1313/mypy-protobuf/blob/main/proto/mypy_protobuf/extensions.proto

It's a fairly stable project for generating type stubs for protobuf.
It's been around since ~2015 (open source since 2017). Since open
sourcing it, it would make sense to reserve some extension numbers in
the global range.

See
https://github.com/nipunn1313/mypy-protobuf/issues/396
